### PR TITLE
README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Trimmomatic


### PR DESCRIPTION
Ant build failed with a following error;

```
[javac] error: Source option 5 is no longer supported. Use 7 or later.
[javac] error: Target option 5 is no longer supported. Use 7 or later.
```
My java set up is as follows;

```
java --version                                                             
openjdk 18.0.1.1 2022-04-22
OpenJDK Runtime Environment (build 18.0.1.1+2-6)
OpenJDK 64-Bit Server VM (build 18.0.1.1+2-6, mixed mode, sharing)
```

This is due to the a line in build.xml ;

`<javac srcdir="${src}" destdir="${dist_build}" debug="true" source="1.5" target="1.5" includeantruntime="false">`

For my case, all I have to do was to change "1.5" to "18";

`<javac srcdir="${src}" destdir="${dist_build}" debug="true" source="18" target="18" includeantruntime="false">`


