### PR TITLE
robust fix:  build error - old version unsupported

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,7 +31,7 @@
 	</target>
 
 	<target name="compile" depends="import">
-		<javac srcdir="${src}" destdir="${dist_build}" debug="true" source="1.5" target="1.5" includeantruntime="false">
+		<javac srcdir="${src}" destdir="${dist_build}" debug="true" release="11" includeantruntime="false">
 			<classpath>
 				<fileset dir="${dist_lib}">
 					<include name="*.jar" />


### PR DESCRIPTION
Similarly to previous PRs #32 and #50, addresses issues with `javac` version compatibility in `build.xml`. 

Instead of changing `target` and `source` (which could lead to issues with accidental later-JRE API usage, see [this note in the Maven docs](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html)), uses the preferred `release` option released in JDK 9 (documentation [here](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html)).

